### PR TITLE
OEL-313: Fix typo in description_list_field composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "guzzlehttp/guzzle": "~6.3",
         "openeuropa/code-review": "~1.0.0-beta2",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/task-runner": "~1.0@beta",,
+        "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0"
     },
     "scripts": {


### PR DESCRIPTION
## OPENEUROPA-313

### Description

Fixed a typo (extra comma) at composer.json

### Change log

- Added: 
- Changed: 
- Deprecated: 
- Removed: 
- Fixed: composer.json
- Security:

### Commands

```sh
[Insert commands here]

```